### PR TITLE
Nat Gateways and EC2 volumes

### DIFF
--- a/environments/ap-southeast-2/prod/main.tf
+++ b/environments/ap-southeast-2/prod/main.tf
@@ -14,9 +14,9 @@ module "vpc" {
   private_subnets = ["10.6.1.0/24", "10.6.2.0/24", "10.6.3.0/24"]
   public_subnets  = ["10.6.101.0/24", "10.6.102.0/24", "10.6.103.0/24"]
 
-  enable_nat_gateway = true
+  enable_nat_gateway = false
   single_nat_gateway = false
-  one_nat_gateway_per_az = true
+  one_nat_gateway_per_az = false
 
   enable_vpn_gateway = false
 

--- a/environments/ap-southeast-2/test/main.tf
+++ b/environments/ap-southeast-2/test/main.tf
@@ -14,8 +14,8 @@ module "vpc" {
   private_subnets = ["10.5.1.0/24", "10.5.2.0/24", "10.5.3.0/24"]
   public_subnets  = ["10.5.101.0/24", "10.5.102.0/24", "10.5.103.0/24"]
 
-  enable_nat_gateway = true
-  single_nat_gateway = true
+  enable_nat_gateway = false
+  single_nat_gateway = false
   one_nat_gateway_per_az = false
 
   enable_vpn_gateway = false

--- a/environments/eu-west-2/prod/main.tf
+++ b/environments/eu-west-2/prod/main.tf
@@ -14,9 +14,9 @@ module "vpc" {
   private_subnets = ["10.4.1.0/24", "10.4.2.0/24", "10.4.3.0/24"]
   public_subnets  = ["10.4.101.0/24", "10.4.102.0/24", "10.4.103.0/24"]
 
-  enable_nat_gateway = true
+  enable_nat_gateway = false
   single_nat_gateway = false
-  one_nat_gateway_per_az = true
+  one_nat_gateway_per_az = false
 
   enable_vpn_gateway = false
 

--- a/environments/eu-west-2/test/main.tf
+++ b/environments/eu-west-2/test/main.tf
@@ -14,8 +14,8 @@ module "vpc" {
   private_subnets = ["10.3.1.0/24", "10.3.2.0/24", "10.3.3.0/24"]
   public_subnets  = ["10.3.101.0/24", "10.3.102.0/24", "10.3.103.0/24"]
 
-  enable_nat_gateway = true
-  single_nat_gateway = true
+  enable_nat_gateway = false
+  single_nat_gateway = false
   one_nat_gateway_per_az = false
 
   enable_vpn_gateway = false

--- a/environments/us-east-1/prod/main.tf
+++ b/environments/us-east-1/prod/main.tf
@@ -14,9 +14,9 @@ module "vpc" {
   private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 
-  enable_nat_gateway = true
+  enable_nat_gateway = false
   single_nat_gateway = false
-  one_nat_gateway_per_az = true
+  one_nat_gateway_per_az = false
 
   enable_vpn_gateway = false
 

--- a/environments/us-east-1/test/main.tf
+++ b/environments/us-east-1/test/main.tf
@@ -14,8 +14,8 @@ module "vpc" {
   private_subnets = ["10.1.1.0/24", "10.1.2.0/24", "10.1.3.0/24"]
   public_subnets  = ["10.1.101.0/24", "10.1.102.0/24", "10.1.103.0/24"]
 
-  enable_nat_gateway = true
-  single_nat_gateway = true
+  enable_nat_gateway = false
+  single_nat_gateway = false
   one_nat_gateway_per_az = false
 
   enable_vpn_gateway = false

--- a/modules/ec2_instance/main.tf
+++ b/modules/ec2_instance/main.tf
@@ -14,6 +14,11 @@ resource "aws_instance" "webserver" {
   associate_public_ip_address = false
   iam_instance_profile = aws_iam_instance_profile.webserver_instance_profile.name
 
+  root_block_device {
+    volume_size = 10 
+    encrypted = true
+  }
+
   user_data = length(var.user_data_file_path) > 0 ? file(var.user_data_file_path) : null
 
 }


### PR DESCRIPTION
- Setting EC2 root volume size and encryption
- Removing NatGateays because they are not requested, and not required according to: 

https://docs.aws.amazon.com/prescriptive-guidance/latest/load-balancer-stickiness/subnets-routing.html

